### PR TITLE
TEEM-15990: Error while unpickling byte-like objects on Python 3

### DIFF
--- a/cryptographic_fields/__init__.py
+++ b/cryptographic_fields/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v1.1'
+__version__ = 'v1.1.1'

--- a/cryptographic_fields/fields.py
+++ b/cryptographic_fields/fields.py
@@ -4,6 +4,7 @@ import sys
 
 import django.db
 import django.db.models
+from django.utils.encoding import force_text
 from django.utils.six import PY2, string_types
 from django.utils.functional import cached_property
 from django.core import validators
@@ -23,13 +24,13 @@ def get_crypter():
     try:
         # Allow the use of key rotation
         if isinstance(configured_keys, (tuple, list)):
-            keys = [cryptography.fernet.Fernet(str(k)) for k in configured_keys]
+            keys = [cryptography.fernet.Fernet(force_text(k)) for k in configured_keys]
         else:
             # else turn the single key into a list of one
-            keys = [cryptography.fernet.Fernet(str(configured_keys)), ]
+            keys = [cryptography.fernet.Fernet(force_text(configured_keys)), ]
     except Exception as e:
         six.reraise(ImproperlyConfigured(
-            'FIELD_ENCRYPTION_KEY defined incorrectly: {}'.format(str(e))), None, sys.exc_info()[2])
+            'FIELD_ENCRYPTION_KEY defined incorrectly: {}'.format(force_text(e))), None, sys.exc_info()[2])
 
     if len(keys) == 0:
         raise ImproperlyConfigured('No keys defined in setting FIELD_ENCRYPTION_KEY')
@@ -83,7 +84,7 @@ class EncryptedMixin(object):
         if PY2:
             return encrypt_str(six.text_type(value))
         # decode the encrypted value to a unicode string, else this breaks in pgsql
-        return (encrypt_str(str(value))).decode('utf-8')
+        return (encrypt_str(force_text(value))).decode('utf-8')
 
     def get_internal_type(self):
         return "TextField"
@@ -130,7 +131,7 @@ class EncryptedBooleanField(EncryptedMixin, django.db.models.BooleanField):
         if PY2:
             return encrypt_str(six.text_type(value))
         # decode the encrypted value to a unicode string, else this breaks in pgsql
-        return encrypt_str(str(value)).decode('utf-8')
+        return encrypt_str(force_text(value)).decode('utf-8')
 
 
 class EncryptedNullBooleanField(EncryptedMixin, django.db.models.NullBooleanField):
@@ -145,7 +146,7 @@ class EncryptedNullBooleanField(EncryptedMixin, django.db.models.NullBooleanFiel
         if PY2:
             return encrypt_str(six.text_type(value))
         # decode the encrypted value to a unicode string, else this breaks in pgsql
-        return encrypt_str(str(value)).decode('utf-8')
+        return encrypt_str(force_text(value)).decode('utf-8')
 
 
 class EncryptedNumberMixin(EncryptedMixin):


### PR DESCRIPTION
# What?
- Fix issue with encrypt/decrypt byte-like objects
- Use `django.utils.encoding.force_text` to ensure 'value' for encrypt/decrypt is `unicode` in Python 2 and `str` in Python 3
- Bump version

# Why?
- Encrypting of byte-like objects isn't working correctly on Python 3 because of a difference between string/bytes in Python versions, in Python 3 bytes literals are always prefixed with b or B thereby we encrypt those bytes with a prefix
- 'force_text' allows to keep same behavior in Python 2 (str remain str) but fix it in python 3