### PR TITLE
TE-36162 : Compatible changes with Django 4.2

### DIFF
--- a/cryptographic_fields/__init__.py
+++ b/cryptographic_fields/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v1.1.3'
+__version__ = 'v2.0'

--- a/cryptographic_fields/__init__.py
+++ b/cryptographic_fields/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 'v2.0'
+__version__ = 'v2.0.0'

--- a/cryptographic_fields/fields.py
+++ b/cryptographic_fields/fields.py
@@ -129,18 +129,11 @@ class EncryptedBooleanField(EncryptedMixin, django.db.models.BooleanField):
         return encrypt_str(force_str(value)).decode('utf-8')
 
 
-class EncryptedNullBooleanField(EncryptedMixin, django.db.models.NullBooleanField):
+class EncryptedNullBooleanField(EncryptedBooleanField):
 
-    def get_db_prep_save(self, value, connection):
-        if value is None:
-            return value
-        if value is True:
-            value = '1'
-        elif value is False:
-            value = '0'
-        # decode the encrypted value to a unicode string, else this breaks in pgsql
-        return encrypt_str(force_str(value)).decode('utf-8')
-
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('null', True)
+        super().__init__(*args, **kwargs)
 
 class EncryptedNumberMixin(EncryptedMixin):
     max_length = 20

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -106,7 +106,7 @@ class TestModelTestCase(TestCase):
         inst.enc_char_field = 'This is a test string!'
         inst.enc_text_field = 'This is a test string2!'
         inst.enc_date_field = datetime.date(2011, 1, 1)
-        inst.enc_datetime_field = datetime.datetime(2012, 2, 1, 1, tzinfo=timezone.UTC())
+        inst.enc_datetime_field = datetime.datetime(2012, 2, 1, 1, tzinfo=timezone.utc)
         inst.enc_boolean_field = True
         inst.enc_null_boolean_field = True
         inst.enc_integer_field = 123456789


### PR DESCRIPTION
What ?
---
- Removed NullBooleanField and replaced with BooleanField(null=True)
- Test case updated_import changed timezone.UTC to timezone.utc

Why ?
---
- NullBooleanField is removed from Django 4.2 and introduced replacement BooleanField(null=True)
- From Django 4.0, the attribute UTC has been removed from django.utils.timezone